### PR TITLE
Update Marvin for cuDNN 4.0rc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /marvin
 *.marvin
 *.tensor
+/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,13 +7,13 @@ find_package(CUDA QUIET REQUIRED)
 set(CUDA_HOST_COMPILER "c++")
 set(CUDA_NVCC_FLAGS "-std=c++11")
 
-set(CUDNN_INCLUDE_DIR /usr/local/cuda/include CACHE PATH
+set(CUDNN_INCLUDE_DIR /usr/local/cudnn/v4rc/include CACHE PATH
         "Path to cudnn header file")
 
 if(APPLE)
-    set(CUDNN_LIB_DIR /usr/local/cuda/lib CACHE PATH "Path to cudnn library")
+    set(CUDNN_LIB_DIR /usr/local/cudnn/v4rc/lib CACHE PATH "Path to cudnn library")
 elseif(UNIX)
-    set(CUDNN_LIB_DIR /usr/local/cuda/lib64 CACHE PATH "Path to cudnn library")
+    set(CUDNN_LIB_DIR /usr/local/cudnn/v4rc/lib64 CACHE PATH "Path to cudnn library")
 elseif(WIN32)
     # TODO
 endif()
@@ -22,5 +22,5 @@ include_directories(${CUDNN_INCLUDE_DIR})
 link_directories(${CUDNN_LIB_DIR})
 
 cuda_add_executable(marvin marvin.hpp marvin.cu)
-target_link_libraries(marvin pthread cudnn
-        ${CUDA_CUBLAS_LIBRARIES} ${CUDA_LIBRARIES})
+target_link_libraries(marvin pthread cudnn 
+        ${CUDA_CUBLAS_LIBRARIES} ${CUDA_LIBRARIES} ${CUDA_curand_LIBRARY})

--- a/README.md
+++ b/README.md
@@ -4,15 +4,16 @@ Marvin is a GPU-only neural network framework made with simplicity, hackability,
 
 ## Dependences
 
-Download [CUDA 7.5](https://developer.nvidia.com/cuda-downloads) and [cuDNN 3](https://developer.nvidia.com/cudnn). You will need to register with NVIDIA. Below are some additional steps to set up cuDNN 3:
+Download [CUDA 7.5](https://developer.nvidia.com/cuda-downloads) and [cuDNN 4rc](https://developer.nvidia.com/cudnn). You will need to register with NVIDIA. Below are some additional steps to set up cuDNN 4rc. **NOTE** We highly recommend that you install different versions of cuDNN to different directories (e.g., ```/usr/local/cudnn/vXX```) because different software packages may require different versions.
 
 ```shell
-CUDA_LIB_DIR=/usr/local/cuda/lib$([[ $(uname) == "Linux" ]] && echo 64)
-echo LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CUDA_LIB_DIR >> ~/.profile && ~/.profile
+LIB_DIR=lib$([[ $(uname) == "Linux" ]] && echo 64)
+CUDNN_LIB_DIR=/usr/local/cudnn/v4rc/$LIB_DIR
+echo LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CUDNN_LIB_DIR >> ~/.profile && ~/.profile
 
 tar zxvf cudnn*.tgz
-sudo cp cuda/lib/* $CUDA_LIB_DIR
-sudo cp cuda/include/* /usr/local/cuda/include
+sudo cp cuda/$LIB_DIR/* $CUDNN_LIB_DIR/
+sudo cp cuda/include/* /usr/local/cudnn/v4rc/include/
 ```
 
 ## Compilation

--- a/compile.sh
+++ b/compile.sh
@@ -4,8 +4,10 @@ export PATH=$PATH:/usr/local/cuda/bin
 
 if uname | grep -q Darwin; then
   CUDA_LIB_DIR=/usr/local/cuda/lib
+  CUDNN_LIB_DIR=/usr/local/cudnn/v4rc/lib
 elif uname | grep -q Linux; then
   CUDA_LIB_DIR=/usr/local/cuda/lib64
+  CUDNN_LIB_DIR=/usr/local/cudnn/v4rc/lib64
 fi
 
-nvcc -std=c++11 -O3 -o marvin marvin.cu -I/usr/local/cuda/include -L$CUDA_LIB_DIR -lcudart -lcublas -lcudnn -lcurand
+nvcc -std=c++11 -O3 -o marvin marvin.cu -I/usr/local/cuda/include -I/usr/local/cudnn/v4rc/include -L$CUDA_LIB_DIR -L$CUDNN_LIB_DIR -lcudart -lcublas -lcudnn -lcurand

--- a/marvin.cu
+++ b/marvin.cu
@@ -1,5 +1,5 @@
 // Please choose a data type to compile
-#define DATATYPE 2
+#define DATATYPE 0
 #include "marvin.hpp"
 
 using namespace marvin;

--- a/marvin.cu
+++ b/marvin.cu
@@ -1,5 +1,5 @@
 // Please choose a data type to compile
-#define DATATYPE 0
+#define DATATYPE 2
 #include "marvin.hpp"
 
 using namespace marvin;

--- a/marvin.hpp
+++ b/marvin.hpp
@@ -3611,7 +3611,8 @@ public:
                                                     &padding[0],
                                                     &stride[0],
                                                     &upscale[0],
-                                                    CUDNN_CROSS_CORRELATION) );
+                                                    CUDNN_CROSS_CORRELATION,
+                                                    CUDNNStorageT) );
 
         std::vector<int> bias_stride(bias_dim.size());
 
@@ -3742,7 +3743,6 @@ public:
                                                         &out_dim_bug[0],
                                                         &strideA[0]) );
                 checkCUDNN(__LINE__,cudnnAddTensor(cudnnHandle,
-                                              CUDNN_ADD_SAME_C,
                                               one,
                                               bias_desc_bug,
                                               bias_dataGPU,
@@ -3764,6 +3764,7 @@ public:
                                                               filter_desc, weight_dataGPU + (g * weight_numel / group),
                                                               out[i]->getDesc(group), out[i]->diffGPU + (g * out[i]->sizeofitem() / group),
                                                               conv_desc,
+                                                              CUDNN_CONVOLUTION_BWD_DATA_ALGO_0, NULL, 0,
                                                               one,
                                                               in[i]->getDesc(group), in[i]->diffGPU + (g * in[i]->sizeofitem() / group)));
                 }
@@ -3780,6 +3781,7 @@ public:
                                                                   in[i]->getDesc(group), in[i]->dataGPU + (g * in[i]->sizeofitem() / group),
                                                                   out[i]->getDesc(group), out[i]->diffGPU + (g * out[i]->sizeofitem() / group),
                                                                   conv_desc,
+                                                                  CUDNN_CONVOLUTION_BWD_FILTER_ALGO_0, NULL, 0,
                                                                   &beta,
                                                                   filter_desc, weight_diffGPU + (g * weight_numel / group)));
                     }

--- a/marvin.hpp
+++ b/marvin.hpp
@@ -12,6 +12,7 @@
     #define sizeofStorageT 2
     #define sizeofComputeT 4
     #define CUDNNStorageT CUDNN_DATA_HALF
+    #define CUDNNConvStorageT CUDNN_DATA_FLOAT
     #define CPUStorage2ComputeT(x) (cpu_half2float(x))
     #define CPUCompute2StorageT(x) (cpu_float2half(x))
     #define GPUStorage2ComputeT(x) (__half2float(x))
@@ -28,6 +29,7 @@
     #define sizeofStorageT 4
     #define sizeofComputeT 4
     #define CUDNNStorageT CUDNN_DATA_FLOAT
+    #define CUDNNConvStorageT CUDNN_DATA_FLOAT
     #define CPUStorage2ComputeT(x) (x)
     #define CPUCompute2StorageT(x) (x)
     #define GPUStorage2ComputeT(x) (x)
@@ -43,6 +45,7 @@
     #define sizeofStorageT 8
     #define sizeofComputeT 8
     #define CUDNNStorageT CUDNN_DATA_DOUBLE
+    #define CUDNNConvStorageT CUDNN_DATA_DOUBLE
     #define CPUStorage2ComputeT(x) (x)
     #define CPUCompute2StorageT(x) (x)
     #define GPUStorage2ComputeT(x) (x)
@@ -387,7 +390,7 @@ public:
         else variable = this->member[name]->returnBool();
     };
 
-    void setOrDie(std::string name, std::vector<float> &variable){
+    void setOrDie(std::string name, std::vector<ComputeT> &variable){
         if (this->member.find(name) == this->member.end())
             FatalError(__LINE__);
         else variable = this->member[name]->returnRealVector();
@@ -3612,7 +3615,7 @@ public:
                                                     &stride[0],
                                                     &upscale[0],
                                                     CUDNN_CROSS_CORRELATION,
-                                                    CUDNNStorageT) );
+                                                    CUDNNConvStorageT) );
 
         std::vector<int> bias_stride(bias_dim.size());
 


### PR DESCRIPTION
Tested on Ubuntu 15.04 and OS X 10.11.1
- cudnnSetConvolutionNdDescriptor now requires cudnn storage type
- cudnnAddTensor no longer allows us to specify add method
- cudnnConvolutionBackwardData and cudnnConvolutionBackwardFilter now take three additional arguments (algo, workSpace, and workSpaceSizeInBytes). The documentation states that if we set these to CUDNN_CONVOLUTION_BWD_{DATA|FILTER}_ALGO_0, NULL, and 0, respectively, we should have identical behavior as before
